### PR TITLE
Depend on struct instead of lpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ var echoWs = new WebSocket('ws://127.0.0.1:8002','echo');
 The client and server modules depend on:
 
   - luasocket
-  - lpack
+  - struct
   - luabitop (if not using Lua 5.2 nor luajit)
   - copas (optionally)
   - lua-ev (optionally)

--- a/lua-websockets.rockspec
+++ b/lua-websockets.rockspec
@@ -15,7 +15,7 @@ description = {
 
 dependencies = {
   "lua >= 5.1",
-  "lpack",
+  "struct",
   "luasocket",
   "luabitop",
   "copas"

--- a/rockspecs/lua-websockets-scm-1.rockspec
+++ b/rockspecs/lua-websockets-scm-1.rockspec
@@ -14,7 +14,7 @@ description = {
 
 dependencies = {
   "lua >= 5.1",
-  "lpack",
+  "struct",
   "luasocket",
   "luabitop",
   "lua-ev",

--- a/spec/frame_spec.lua
+++ b/spec/frame_spec.lua
@@ -1,7 +1,6 @@
 package.path = package.path..'../src'
 
 local frame = require'websocket.frame'
-require'pack'
 
 local bytes = string.char
 

--- a/spec/handshake_spec.lua
+++ b/spec/handshake_spec.lua
@@ -6,7 +6,6 @@ local url = 'ws://127.0.0.1:'..port
 
 local handshake = require'websocket.handshake'
 local socket = require'socket'
-require'pack'
 
 local request_lines = {
   'GET /chat HTTP/1.1',

--- a/spec/tools_spec.lua
+++ b/spec/tools_spec.lua
@@ -1,7 +1,6 @@
 package.path = package.path..'../src'
 
 local tools = require'websocket.tools'
-require'pack'
 
 local bytes = string.char
 

--- a/src/websocket/frame.lua
+++ b/src/websocket/frame.lua
@@ -1,12 +1,10 @@
 -- Following Websocket RFC: http://tools.ietf.org/html/rfc6455
-require'pack'
+local struct = require'struct'
 local bit = require'websocket.bit'
 local band = bit.band
 local bxor = bit.bxor
 local bor = bit.bor
-local sunpack = string.unpack
 local tremove = table.remove
-local spack = string.pack
 local srep = string.rep
 local ssub = string.sub
 local sbyte = string.byte
@@ -38,7 +36,7 @@ local xor_mask = function(encoded,mask,payload)
     local original = {sbyte(encoded,p,last)}
     for i=1,#original do
       local j = (i-1) % 4 + 1
-      transformed[i] = bxor(original[i],mask[j])
+      transformed[i] = band(bxor(original[i],mask[j]), 0xFF)
     end
     local xored = schar(unpack(transformed))
     tinsert(transformed_arr,xored)
@@ -59,15 +57,15 @@ local encode = function(data,opcode,masked,fin)
   local len = #data
   if len < 126 then
     payload = bor(payload,len)
-    encoded = spack('bb',header,payload)
+    encoded = struct.pack('bb',header,payload)
   elseif len < 0xffff then
     payload = bor(payload,126)
-    encoded = spack('bb>H',header,payload,len)
+    encoded = struct.pack('bb>H',header,payload,len)
   elseif len < 2^53 then
     local high = math.floor(len/2^32)
     local low = len - high*2^32
     payload = bor(payload,127)
-    encoded = spack('bb>I>I',header,payload,high,low)
+    encoded = struct.pack('bb>I>I',header,payload,high,low)
   end
   if not masked then
     encoded = encoded..data
@@ -77,7 +75,7 @@ local encode = function(data,opcode,masked,fin)
     local m3 = math.random(0,0xff)
     local m4 = math.random(0,0xff)
     local mask = {m1,m2,m3,m4}
-    encoded = encoded..spack('bbbb',m1,m2,m3,m4)
+    encoded = encoded..struct.pack('bbbb',m1,m2,m3,m4)
     encoded = encoded..xor_mask(data,mask,#data)
   end
   return encoded
@@ -88,7 +86,7 @@ local decode = function(encoded)
   if #encoded < 2 then
     return nil,2
   end
-  local pos,header,payload = sunpack(encoded,'bb')
+  local header,payload,pos = struct.unpack('bb',encoded)
   local high,low
   encoded = ssub(encoded,pos)
   local bytes = 2
@@ -101,12 +99,12 @@ local decode = function(encoded)
       if #encoded < 2 then
         return nil,2
       end
-      pos,payload = sunpack(encoded,'>H')
+      payload,pos = struct.unpack('>H',encoded)
     elseif payload == 127 then
       if #encoded < 8 then
         return nil,8
       end
-      pos,high,low = sunpack(encoded,'>I>I')
+      high,low,pos = struct.unpack('>I>I',encoded)
       payload = high*2^32 + low
       if payload < 0xffff or payload > 2^53 then
         assert(false,'INVALID PAYLOAD '..payload)
@@ -123,7 +121,7 @@ local decode = function(encoded)
     if bytes_short > 0 then
       return nil,bytes_short
     end
-    local pos,m1,m2,m3,m4 = sunpack(encoded,'bbbb')
+    local m1,m2,m3,m4,pos = struct.unpack('bbbb',encoded)
     encoded = ssub(encoded,pos)
     local mask = {
       m1,m2,m3,m4
@@ -147,7 +145,7 @@ end
 
 local encode_close = function(code,reason)
   if code then
-    local data = spack('>H',code)
+    local data = struct.pack('>H',code)
     if reason then
       data = data..tostring(reason)
     end
@@ -160,7 +158,7 @@ local decode_close = function(data)
   local _,code,reason
   if data then
     if #data > 1 then
-      _,code = sunpack(data,'>H')
+      code = struct.unpack('>H',data)
     end
     if #data > 2 then
       reason = data:sub(3)

--- a/src/websocket/handshake.lua
+++ b/src/websocket/handshake.lua
@@ -1,6 +1,3 @@
-
-require'pack'
-
 local sha1 = require'websocket.tools'.sha1
 local base64 = require'websocket.tools'.base64
 local tinsert = table.insert

--- a/src/websocket/tools.lua
+++ b/src/websocket/tools.lua
@@ -1,4 +1,4 @@
-require'pack'
+local struct = require'struct'
 local socket = require'socket'
 local bit = require'websocket.bit'
 local rol = bit.rol
@@ -8,7 +8,6 @@ local band = bit.band
 local bnot = bit.bnot
 local lshift = bit.lshift
 local rshift = bit.rshift
-local spack = string.pack
 local sunpack = string.unpack
 local srep = string.rep
 local schar = string.char
@@ -45,16 +44,16 @@ local sha1 = function(msg)
   -- append 64 big endian length
   local high = math.floor(bits/2^32)
   local low = bits - high*2^32
-  msg = msg..spack('>I>I',high,low)
+  msg = msg..struct.pack('>I>I',high,low)
   
   assert(#msg % 64 == 0,#msg % 64)
   
   for j=1,#msg,64 do
     local chunk = msg:sub(j,j+63)
     assert(#chunk==64,#chunk)
-    local words = {sunpack(chunk,srep('>I',16))}
-    -- index 1 contains fragment from unpack
-    tremove(words,1)
+    local words = {struct.unpack(srep('>I',16),chunk)}
+    -- last item contains the index in chunk where it stopped reading
+    tremove(words,17)
     assert(#words==16)
     for i=17,80 do
       words[i] = bxor(words[i-3],words[i-8],words[i-14],words[i-16])
@@ -105,7 +104,7 @@ local sha1 = function(msg)
   h3 = band(h3,0xffffffff)
   h4 = band(h4,0xffffffff)
   
-  return spack('>i>i>i>i>i',h0,h1,h2,h3,h4)
+  return struct.pack('>i>i>i>i>i',h0,h1,h2,h3,h4)
 end
 
 local base64chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
@@ -163,7 +162,7 @@ local generate_key = function()
   local r2 = mrandom(0,0xfffffff)
   local r3 = mrandom(0,0xfffffff)
   local r4 = mrandom(0,0xfffffff)
-  local key = spack('IIII',r1,r2,r3,r4)
+  local key = struct.pack('IIII',r1,r2,r3,r4)
   assert(#key==16,#key)
   return base64_encode(key)
 end


### PR DESCRIPTION
The struct module is actually available either for Lua 5.1 and 5.2.
lpack was the only dependency preventing lua-websocket to be compiled
for Lua 5.2.
