### PR TITLE
Missing compatibility for Lua 5.2 bit operations

### DIFF
--- a/src/websocket/bit.lua
+++ b/src/websocket/bit.lua
@@ -1,6 +1,8 @@
 local has_bit32,bit = pcall(require,'bit32')
 if has_bit32 then
   -- lua 5.2
+  bit.rol = bit32.lrotate
+  bit.ror = bit32.rrotate
   return bit
 else
   -- luajit / lua 5.1 + luabitop


### PR DESCRIPTION
In the standard library provided by Lua 5.2, bit.rol and bit.rol are
named bit32.lrotate and bit32.rrotate.
