### PR TITLE
Do not force IPv6 addresses with LuaSocket >= 3

### DIFF
--- a/src/websocket/server_copas.lua
+++ b/src/websocket/server_copas.lua
@@ -54,7 +54,7 @@ local listen = function(opts)
   local copas = require'copas'
   assert(opts and (opts.protocols or opts.default))
   local on_error = opts.on_error or function(s) print(s) end
-  local listener,err = tools.bind(opts.interface or '*',opts.port or 80)
+  local listener,err = socket.bind(opts.interface or '*',opts.port or 80)
   if err then
     error(err)
   end

--- a/src/websocket/server_ev.lua
+++ b/src/websocket/server_ev.lua
@@ -161,7 +161,7 @@ local listen = function(opts)
   self.on_error = function(self,on_error)
     user_on_error = on_error
   end
-  local listener,err = tools.bind(opts.interface or '*',opts.port or 80)
+  local listener,err = socket.bind(opts.interface or '*',opts.port or 80)
   if not listener then
     error(err)
   end

--- a/src/websocket/tools.lua
+++ b/src/websocket/tools.lua
@@ -168,35 +168,6 @@ local generate_key = function()
   return base64_encode(key)
 end
 
-local bind = function(host,port)
-  if socket.tcp6 then
-    local server = socket.tcp6()
-    local _,err = server:setoption('ipv6-v6only',false)
-    if err then
-      server:close()
-      return nil,err
-    end
-    _,err = server:setoption("reuseaddr", true)
-    if err then
-      server:close()
-      return nil,err
-    end
-    _,err = server:bind(host,port)
-    if err then
-      server:close()
-      return nil,err
-    end
-    _,err = server:listen()
-    if err then
-      server:close()
-      return nil,err
-    end
-    return server
-  else
-    return socket.bind(host,port)
-  end
-end
-
 return {
   sha1 = sha1,
   base64 = {
@@ -204,5 +175,4 @@ return {
   },
   parse_url = parse_url,
   generate_key = generate_key,
-  bind = bind,
 }


### PR DESCRIPTION
If socket.tcp6 was valorized (and this is the case on luasocket 3), the
tools.bind helper function effectively forced the use of IPv6 addresses.
The "ipv6-v6only" option diretly maps to IPV6_V6ONLY and it only affects
the communication of an INET6 socket:

https://tools.ietf.org/html/rfc3493#section-5.3

The socket.bind API in LuaSocket 3 already handles inet and inet6
addresses, so there is no need for tools.bind:

https://github.com/diegonehab/luasocket/blob/v3.0-rc1/src/socket.lua#L27
