### PR TITLE
Delay load backends.

### DIFF
--- a/rockspecs/lua-websockets-scm-1.rockspec
+++ b/rockspecs/lua-websockets-scm-1.rockspec
@@ -28,6 +28,7 @@ build = {
       ['websocket'] = 'src/websocket.lua',
       ['websocket.sync'] = 'src/websocket/sync.lua',
       ['websocket.client'] = 'src/websocket/client.lua',
+      ['websocket.client_sync'] = 'src/websocket/client_sync.lua',
       ['websocket.client_ev'] = 'src/websocket/client_ev.lua',
       ['websocket.client_copas'] = 'src/websocket/client_copas.lua',
       ['websocket.ev_common'] = 'src/websocket/ev_common.lua',

--- a/src/websocket/client.lua
+++ b/src/websocket/client.lua
@@ -36,10 +36,11 @@ local new = function(ws)
   return self
 end
 
-
-return {
-  new = new,
+return setmetatable({
+  new  = new,
   sync = new,
-  ev = require'websocket.client_ev',
-  copas = require'websocket.client_copas'
-}
+},{__index = function(self, name)
+  local backend = require("websocket.client_" .. name)
+  self[name] = backend
+  return backend
+end})

--- a/src/websocket/client.lua
+++ b/src/websocket/client.lua
@@ -1,46 +1,7 @@
-local socket = require'socket'
-local sync = require'websocket.sync'
-local tools = require'websocket.tools'
-
-local new = function(ws)
-  ws =  ws or {}
-  local self = {}
-  
-  self.sock_connect = function(self,host,port)
-    self.sock = socket.tcp()
-    if ws.timeout ~= nil then
-      self.sock:settimeout(ws.timeout)
-    end
-    local _,err = self.sock:connect(host,port)
-    if err then
-      self.sock:close()
-      return nil,err
-    end
-  end
-  
-  self.sock_send = function(self,...)
-    return self.sock:send(...)
-  end
-  
-  self.sock_receive = function(self,...)
-    return self.sock:receive(...)
-  end
-  
-  self.sock_close = function(self)
-    self.sock:shutdown()
-    self.sock:close()
-  end
-  
-  self = sync.extend(self)
-  self.state = 'CLOSED'
-  return self
-end
-
-return setmetatable({
-  new  = new,
-  sync = new,
-},{__index = function(self, name)
+return setmetatable({},{__index = function(self, name)
+  if name == 'new' then name = 'sync' end
   local backend = require("websocket.client_" .. name)
   self[name] = backend
+  if name == 'sync' then self.new = backend end
   return backend
 end})

--- a/src/websocket/client_sync.lua
+++ b/src/websocket/client_sync.lua
@@ -1,0 +1,39 @@
+local socket = require'socket'
+local sync = require'websocket.sync'
+local tools = require'websocket.tools'
+
+local new = function(ws)
+  ws =  ws or {}
+  local self = {}
+  
+  self.sock_connect = function(self,host,port)
+    self.sock = socket.tcp()
+    if ws.timeout ~= nil then
+      self.sock:settimeout(ws.timeout)
+    end
+    local _,err = self.sock:connect(host,port)
+    if err then
+      self.sock:close()
+      return nil,err
+    end
+  end
+  
+  self.sock_send = function(self,...)
+    return self.sock:send(...)
+  end
+  
+  self.sock_receive = function(self,...)
+    return self.sock:receive(...)
+  end
+  
+  self.sock_close = function(self)
+    self.sock:shutdown()
+    self.sock:close()
+  end
+  
+  self = sync.extend(self)
+  self.state = 'CLOSED'
+  return self
+end
+
+return new

--- a/src/websocket/server.lua
+++ b/src/websocket/server.lua
@@ -1,4 +1,5 @@
-return {
-  ev = require'websocket.server_ev',
-  copas = require'websocket.server_copas',
-}
+return setmetatable({},{__index = function(self, name)
+  local backend = require("websocket.server_" .. name)
+  self[name] = backend
+  return backend
+end})


### PR DESCRIPTION
This allows install only needed backends
My idea is provide several rockspect for
*  `websocket-core` include only modules for work with messages. This module depends from `struct` and `bit32` libraries.
*  `websocket-sync`, `websocket-ev`, `websocket-copas` modules that depends from `core` and from other libraries.
*  `websocket` this module for compatability and it just has dependecies from  `websocket-sync`, `websocket-ev`, `websocket-copas`

Also it would be possible provide indepndent backends as separate modules e.g. `websocket-lluv`

