### PR TITLE
Fix. Pack messages with payload of length 65535.

### DIFF
--- a/src/websocket/frame.lua
+++ b/src/websocket/frame.lua
@@ -62,7 +62,7 @@ local encode = function(data,opcode,masked,fin)
   if len < 126 then
     payload = bor(payload,len)
     encoded = strpack('bb',header,payload)
-  elseif len < 0xffff then
+  elseif len <= 0xffff then
     payload = bor(payload,126)
     encoded = strpack('bb>H',header,payload,len)
   elseif len < 2^53 then


### PR DESCRIPTION
I testd this with `Autobahn WebSockets 0.7.1/0.10.0 Fuzzing Server`