### PR TITLE
Added support for multiple websocket subprotocols

### DIFF
--- a/src/websocket/client_ev.lua
+++ b/src/websocket/client_ev.lua
@@ -49,7 +49,7 @@ local ev = function(ws)
       sock = nil
     end
   end
-  
+
   local on_close = function(was_clean,code,reason)
     cleanup()
     self.state = 'CLOSED'
@@ -100,12 +100,12 @@ local ev = function(ws)
       end
     end
   end
-  
+
   self.send = function(_,message,opcode)
     local encoded = frame.encode(message,opcode or frame.TEXT,true)
     async_send(encoded, nil, handle_socket_err)
   end
-  
+
   self.connect = function(_,url,ws_protocol)
     if self.state ~= 'CLOSED' then
       on_error('wrong state',true)
@@ -115,6 +115,12 @@ local ev = function(ws)
     if protocol ~= 'ws' then
       on_error('bad protocol')
       return
+    end
+    local ws_protocols_tbl = {''}
+    if type(ws_protocol) == 'string' then
+        ws_protocols_tbl = {ws_protocol}
+    elseif type(ws_protocol) == 'table' then
+        ws_protocols_tbl = ws_protocol
     end
     self.state = 'CONNECTING'
     assert(not sock)
@@ -134,7 +140,7 @@ local ev = function(ws)
           key = key,
           host = host,
           port = port,
-          protocols = {ws_protocol or ''},
+          protocols = ws_protocols_tbl,
           origin = ws.origin,
           uri = uri
         }
@@ -194,23 +200,23 @@ local ev = function(ws)
       on_error(err)
     end
   end
-  
+
   self.on_close = function(_,on_close_arg)
     user_on_close = on_close_arg
   end
-  
+
   self.on_error = function(_,on_error_arg)
     user_on_error = on_error_arg
   end
-  
+
   self.on_open = function(_,on_open_arg)
     user_on_open = on_open_arg
   end
-  
+
   self.on_message = function(_,on_message_arg)
     user_on_message = on_message_arg
   end
-  
+
   self.close = function(_,code,reason,timeout)
     if handshake_io then
       handshake_io:stop(loop)
@@ -235,7 +241,7 @@ local ev = function(ws)
       close_timer:start(loop)
     end
   end
-  
+
   return self
 end
 

--- a/src/websocket/sync.lua
+++ b/src/websocket/sync.lua
@@ -129,13 +129,19 @@ local connect = function(self,ws_url,ws_protocol)
   if err then
     return nil,err
   end
+  local ws_protocols_tbl = {''}
+  if type(ws_protocol) == 'string' then
+      ws_protocols_tbl = {ws_protocol}
+  elseif type(ws_protocol) == 'table' then
+      ws_protocols_tbl = ws_protocol
+  end
   local key = tools.generate_key()
   local req = handshake.upgrade_request
   {
     key = key,
     host = host,
     port = port,
-    protocols = {ws_protocol or ''},
+    protocols = ws_protocols_tbl,
     uri = uri
   }
   local n,err = self:sock_send(req)


### PR DESCRIPTION
Hi! 
I've faced a problem, that i cannot specify more that one websocket subprotocol. I've fixed that without breaking API. So you can specify nil, string or arrray of strings.