### PR TITLE
Fixed #59: get response with selected subprotocol and ws headers

### DIFF
--- a/spec/client_ev_spec.lua
+++ b/spec/client_ev_spec.lua
@@ -19,24 +19,27 @@ describe(
         assert.is_table(client)
         assert.is_function(client.ev)
       end)
-    
+
     it(
       'can be constructed',
       function()
         wsc = client.ev()
       end)
-    
+
     it(
       'can connect and calls on_open'..req_ws,
       function(done)
         settimeout(10)
-        wsc:on_open(async(function(ws)
+        wsc:on_open(async(function(ws,protocol,headers)
               assert.is_equal(ws,wsc)
+              assert.is_equal(protocol,'echo-protocol')
+              assert.is.truthy(headers['sec-websocket-accept'])
+              assert.is.truthy(headers['sec-websocket-protocol'])
               done()
           end))
         wsc:connect(url,'echo-protocol')
       end)
-    
+
     it(
       'calls on_error if already connected'..req_ws,
       function(done)
@@ -50,7 +53,7 @@ describe(
           end))
         wsc:connect(url,'echo-protocol')
       end)
-    
+
     it(
       'calls on_error on bad protocol'..req_ws,
       function(done)
@@ -63,7 +66,7 @@ describe(
           end))
         wsc:connect('ws2://127.0.0.1:'..port,'echo-protocol')
       end)
-    
+
     it(
       'can parse HTTP request header byte per byte',
       function(done)
@@ -103,7 +106,7 @@ describe(
             end
           end,0.0001,0.0001):start(ev.Loop.default)
       end)
-    
+
     it(
       'properly calls on_error if socket error on handshake occurs',
       function(done)
@@ -140,7 +143,7 @@ describe(
             end
           end,0.0001,0.0001):start(ev.Loop.default)
       end)
-    
+
     it(
       'can open and close immediatly (in CLOSING state)'..req_ws,
       function(done)
@@ -155,7 +158,7 @@ describe(
         wsc:connect(url,'echo-protocol')
         wsc:close()
       end)
-    
+
     it(
       'socket err gets forwarded to on_error',
       function(done)
@@ -175,8 +178,8 @@ describe(
           end))
         wsc:connect('ws://does_not_exist','echo-protocol')
       end)
-    
-    
+
+
     it(
       'can send and receive data'..req_ws,
       function(done)
@@ -195,7 +198,7 @@ describe(
           end)
         wsc:connect(url,'echo-protocol')
       end)
-    
+
     local random_text = function(len)
       local chars = {}
       for i=1,len do
@@ -203,7 +206,7 @@ describe(
       end
       return table.concat(chars)
     end
-    
+
     it(
       'can send and receive data 127 byte messages'..req_ws,
       function(done)
@@ -219,7 +222,7 @@ describe(
           end))
         wsc:send(msg)
       end)
-    
+
     it(
       'can send and receive data 0xffff-1 byte messages'..req_ws,
       function(done)
@@ -235,7 +238,7 @@ describe(
           end))
         wsc:send(msg)
       end)
-    
+
     it(
       'can send and receive data 0xffff+1 byte messages'..req_ws,
       function(done)
@@ -251,7 +254,7 @@ describe(
           end))
         wsc:send(msg)
       end)
-    
+
     it(
       'closes cleanly'..req_ws,
       function(done)
@@ -264,7 +267,7 @@ describe(
           end))
         wsc:close()
       end)
-    
+
     it(
       'echoing 10 messages works'..req_ws,
       function(done)
@@ -296,7 +299,7 @@ describe(
                       ws:close()
                     end
                 end))
-              
+
               for i=1,10 do
                 wsc:send(msg..i)
               end

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -15,20 +15,20 @@ describe(
         assert.is_function(client.new)
         assert.is_equal(client.new,client.sync)
       end)
-    
+
     it(
       'can be constructed and closed',
       function()
         wsc = client.new()
         wsc:close()
       end)
-    
+
     it(
       'can be constructed with timeout',
       function()
         wsc = client.new({timeout=1})
       end)
-    
+
     it(
       'returns error when trying to send or receive when not connected',
       function()
@@ -37,8 +37,8 @@ describe(
         assert.is_false(was_clean)
         assert.is_equal(code,1006)
         assert.is_equal(reason,'wrong state')
-        
-        
+
+
         local message,opcode,was_clean,code,reason = wsc:receive()
         assert.is_nil(message)
         assert.is_nil(opcode)
@@ -46,14 +46,18 @@ describe(
         assert.is_equal(code,1006)
         assert.is_equal(reason,'wrong state')
       end)
-    
+
     it(
       'can connect (requires external websocket server)',
       function()
         assert.is_function(wsc.connect)
-        wsc:connect(url,'echo-protocol')
+        local ok, protocol, headers = wsc:connect(url,'echo-protocol')
+        assert.is_truthy(ok)
+        assert.is_equal(protocol,'echo-protocol')
+        assert.is.truthy(headers['sec-websocket-accept'])
+        assert.is.truthy(headers['sec-websocket-protocol'])
       end)
-    
+
     it(
       'returns error on non-ws protocol',
       function()
@@ -62,7 +66,7 @@ describe(
         assert.is_falsy(ok)
         assert.is_equal(err,'bad protocol')
       end)
-    
+
     it(
       'forwards socket errors',
       function()
@@ -70,7 +74,7 @@ describe(
         local ok,err = c:connect('ws://127.0.0.1:1','echo-protocol')
         assert.is_nil(ok)
         assert.is_equal(err,'connection refused')
-        
+
         local ok,err = c:connect('ws://notexisting:8089','echo-protocol')
         assert.is_nil(ok)
         if socket.tcp6 then
@@ -79,7 +83,7 @@ describe(
           assert.is_equal(err,'host not found')
         end
       end)
-    
+
     it(
       'returns error when sending in non-open state (requires external websocket server @port 8081)',
       function()
@@ -89,7 +93,7 @@ describe(
         assert.is_false(was_clean)
         assert.is_equal(code,1006)
         assert.is_equal(reason,'wrong state')
-        
+
         c:connect(url,'echo-protocol')
         c:close()
         local ok,was_clean,code,reason = c:send('test')
@@ -98,7 +102,7 @@ describe(
         assert.is_equal(code,1006)
         assert.is_equal(reason,'wrong state')
       end)
-    
+
     it(
       'returns error when connecting twice (requires external websocket server @port 8081)',
       function()
@@ -106,19 +110,19 @@ describe(
         local ok,err = c:connect(url,'echo-protocol')
         assert.is_truthy(ok)
         assert.is_nil(err)
-        
+
         local ok,err = c:connect(url,'echo-protocol')
         assert.is_falsy(ok)
         assert.is_equal(err,'wrong state')
       end)
-    
+
     it(
       'can send (requires external websocket server @port 8081)',
       function()
         assert.is_same(type(wsc.send),'function')
         wsc:send('Hello again')
       end)
-    
+
     it(
       'can receive (requires external websocket server @port 8081)',
       function()
@@ -126,7 +130,7 @@ describe(
         local echoed = wsc:receive()
         assert.is_same(echoed,'Hello again')
       end)
-    
+
     local random_text = function(len)
       local chars = {}
       for i=1,len do
@@ -134,7 +138,7 @@ describe(
       end
       return table.concat(chars)
     end
-    
+
     it(
       'can send with payload 127 (requires external websocket server @port 8081)',
       function()
@@ -143,7 +147,7 @@ describe(
         local echoed = wsc:receive()
         assert.is_same(text,echoed)
       end)
-    
+
     it(
       'can send with payload 0xffff-1 (requires external websocket server @port 8081)',
       function()
@@ -154,7 +158,7 @@ describe(
         assert.is_same(#text,#echoed)
         assert.is_same(text,echoed)
       end)
-    
+
     it(
       'can send with payload 0xffff+1 (requires external websocket server @port 8081)',
       function()
@@ -165,7 +169,7 @@ describe(
         assert.is_same(#text,#echoed)
         assert.is_same(text,echoed)
       end)
-    
+
     it(
       'can close cleanly (requires external websocket server @port 8081)',
       function()
@@ -174,5 +178,5 @@ describe(
         assert.is_true(code >= 1000)
         assert.is_string(reason)
       end)
-    
+
   end)

--- a/src/websocket/client_ev.lua
+++ b/src/websocket/client_ev.lua
@@ -67,10 +67,10 @@ local ev = function(ws)
       print('Error',err)
     end
   end
-  local on_open = function()
+  local on_open = function(_,headers)
     self.state = 'OPEN'
     if user_on_open then
-      user_on_open(self)
+      user_on_open(self,headers['sec-websocket-protocol'],headers)
     end
   end
   local handle_socket_err = function(err,io,sock)
@@ -183,7 +183,7 @@ local ev = function(ws)
                 sock,loop,
                 on_message,
               handle_socket_err)
-              on_open(self)
+              on_open(self, headers)
             end
             handshake_io = ev.IO.new(read_upgrade,fd,ev.READ)
             handshake_io:start(loop)-- handshake


### PR DESCRIPTION
Hi, guys! On this weekend i decided to implement this feature. But i was a bit confused: in client_ev we can not simply return headers, 'cause things are async. So i extended response form on_open function — now it returns websocket object, server selected protocol and all response headers. 
For sync client — all return points in connect function are extended appropriately. 