### PR TITLE
Fix. Try load `bit` library before `bit32`

### DIFF
--- a/src/websocket/bit.lua
+++ b/src/websocket/bit.lua
@@ -1,10 +1,10 @@
-local has_bit32,bit = pcall(require,'bit32')
-if has_bit32 then
+-- luajit / lua 5.1 + luabitop
+local ok, bit = pcall(require, 'bit')
+if not ok then
   -- lua 5.2 / bit32 library
+  bit = require 'bit32'
   bit.rol = bit.lrotate
   bit.ror = bit.rrotate
-  return bit
-else
-  -- luajit / lua 5.1 + luabitop
-  return require'bit'
 end
+
+return bit


### PR DESCRIPTION
This is necessary because if you have Lua 5.1 and LuaJIT and you have
`bit32` library LuaJIT can find this library and will use it instead of
builtin one.