### PR TITLE
Close the copas server properly by removing it from copas loop

### DIFF
--- a/src/websocket/server_copas.lua
+++ b/src/websocket/server_copas.lua
@@ -128,7 +128,7 @@ local listen = function(opts)
     end)
   local self = {}
   self.close = function(_,keep_clients)
-    listener:close()
+    copas.removeserver(listener)
     listener = nil
     if not keep_clients then
       for protocol,clients in pairs(clients) do


### PR DESCRIPTION
The problem:

There is no way to shutdown copas server properly. Copas loop is never finished, since copas:finished() is never true, because websocket server that was added by copas:addserver(listener,...) is never removed from copas.

Solution:

In server_copas.lua, line 131 you call listener:close()

```
  self.close = function(_,keep_clients)
    listener:close()
    listener = nil
```

Instead, call copas:removeserver(listener). This removes the server from copas pool of tasks, and closes the socket (i.e., listener:close() is implied).

After this fix, server:close() method works fine and the script ends properly & almost immediately.