### PR TITLE
Set socket timeout to opts.timeout or 1 -- to prevent constant reads

### DIFF
--- a/src/websocket/server_ev.lua
+++ b/src/websocket/server_ev.lua
@@ -166,7 +166,7 @@ local listen = function(opts)
   if not listener then
     error(err)
   end
-  listener:settimeout(0)
+  listener:settimeout(1)
   
   self.sock = function()
     return listener
@@ -175,7 +175,7 @@ local listen = function(opts)
   local listen_io = ev.IO.new(
     function()
       local client_sock = listener:accept()
-      client_sock:settimeout(0)
+      client_sock:settimeout(1)
       assert(client_sock)
       local request = {}
       local last

--- a/src/websocket/server_ev.lua
+++ b/src/websocket/server_ev.lua
@@ -166,7 +166,7 @@ local listen = function(opts)
   if not listener then
     error(err)
   end
-  listener:settimeout(1)
+  listener:settimeout(opts.timeout or 1)
   
   self.sock = function()
     return listener
@@ -175,7 +175,7 @@ local listen = function(opts)
   local listen_io = ev.IO.new(
     function()
       local client_sock = listener:accept()
-      client_sock:settimeout(1)
+      client_sock:settimeout(opts.timeout or 1)
       assert(client_sock)
       local request = {}
       local last


### PR DESCRIPTION
Defaults to 1 ms timeout (to prevent continuous reading on the socket even if no information is available). Added an option "timeout" in case there are event less requirements for socket performance speed. 

Previously, the defaults were 0 and the socket would eat all my CPU when using chrome.