### PR TITLE
Extracted mime instantiation to outer scope

### DIFF
--- a/src/websocket/tools.lua
+++ b/src/websocket/tools.lua
@@ -1,4 +1,5 @@
 local bit = require'websocket.bit'
+local mime = require'mime'
 local rol = bit.rol
 local bxor = bit.bxor
 local bor = bit.bor
@@ -158,7 +159,6 @@ local sha1_wiki = function(msg)
 end
 
 local base64_encode = function(data)
-  local mime = require'mime'
   return (mime.b64(data))
 end
 


### PR DESCRIPTION
...so that even if base64_encode is called later on without require function available, the code still works.

This is for the case that if we instantiate a websocket client in a pseudo sandboxed environment where the require function has been set to nil (_G.require = nil) we can still use the websocket client without it crashing. 