### PR TITLE
Server Handshake Reply

### DIFF
--- a/src/websocket/handshake.lua
+++ b/src/websocket/handshake.lua
@@ -62,9 +62,10 @@ end
 
 local accept_upgrade = function(request,protocols)
   local headers = http_headers(request)
-  if headers['upgrade'] ~= 'websocket' or
+  if not headers['upgrade'] or
+  headers['upgrade']:lower() ~= 'websocket' or
   not headers['connection'] or
-  not headers['connection']:match('upgrade') or
+  not headers['connection']:lower():match('upgrade') or
   headers['sec-websocket-key'] == nil or
   headers['sec-websocket-version'] ~= '13' then
     return nil,'HTTP/1.1 400 Bad Request\r\n\r\n'
@@ -84,9 +85,9 @@ local accept_upgrade = function(request,protocols)
     end
   end
   local lines = {
-    'HTTP/1.1 101 Switching Protocols',
-    'Upgrade: websocket',
-    'Connection: '..headers['connection'],
+    'HTTP/1.1 101 Switching Protocols', -- 4.2.2.5.1
+    'Upgrade: websocket', -- 4.2.2.5.2
+    'Connection: Upgrade', -- 4.2.2.5.3
     string.format('Sec-WebSocket-Accept: %s',sec_websocket_accept(headers['sec-websocket-key'])),
   }
   if prot then


### PR DESCRIPTION
Just updating library to conform to the RFC section 4.2.2.5. 

Discovered while using the .NET websocket to connect to a server running Lua websockets. The connection request was for 'Upgrade,Keep-Alive' and when the server tried to accept the connection it replied back with 'Connection: Upgrade,Keep-Alive' which broken the client side, probably because of the 4.2.2.5.3 violation.