### PR TITLE
Update rockspec to use git+https protocol

### DIFF
--- a/lua-websockets.rockspec
+++ b/lua-websockets.rockspec
@@ -2,7 +2,7 @@ package = "lua-websockets"
 version = "@VERSION@-1"
 
 source = {
-   url = "git://github.com/lipp/lua-websockets.git",     
+   url = "git+https://github.com/lipp/lua-websockets.git",     
    tag = "@VERSION@"
 }
 


### PR DESCRIPTION
GitHub has deprecated unauthenticated git:// access