### PR TITLE
src/websocket/bit.lua: add support for bitop-lua

### DIFF
--- a/src/websocket/bit.lua
+++ b/src/websocket/bit.lua
@@ -4,7 +4,13 @@ if has_bit32 then
   bit.rol = bit.lrotate
   bit.ror = bit.rrotate
   return bit
-else
+end
+
+local has_bit
+has_bit, bit = pcall(require,'bit')
+if has_bit then
   -- luajit / lua 5.1 + luabitop
   return require'bit'
 end
+
+return (require 'bitop.funcs').bit


### PR DESCRIPTION
use `bitop-lua` if `bit32` and `bit` modules are not found