### PR TITLE
Add SNI

### DIFF
--- a/src/websocket/sync.lua
+++ b/src/websocket/sync.lua
@@ -129,6 +129,7 @@ local connect = function(self,ws_url,ws_protocol,ssl_params)
   end
   if protocol == 'wss' then
     self.sock = ssl.wrap(self.sock, ssl_params)
+    self.sock:sni(host)
     self.sock:dohandshake()
   elseif protocol ~= "ws" then
     return nil, 'bad protocol'


### PR DESCRIPTION
Perform SNI (Server Name Indication) for secure websocket (wss) connections.

The two server's I've tested this on so far (Twitch, and echo.websocket.org) fail to perform the connection process unless you first perform SNI.